### PR TITLE
support for multiple audiences

### DIFF
--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -148,7 +149,7 @@ namespace AspNet.Security.OAuth.Introspection {
         protected virtual Task<bool> ValidateAudienceAsync(JObject payload) {
             // If no explicit audience has been configured,
             // skip the default audience validation.
-            if (string.IsNullOrEmpty(Options.Audience)) {
+            if (Options.Audiences.Count == 0) {
                 return Task.FromResult(true);
             }
 
@@ -164,20 +165,19 @@ namespace AspNet.Security.OAuth.Introspection {
                 case JTokenType.Array: {
                     // When the "aud" claim is an array, at least one value must correspond
                     // to the audience registered in the introspection middleware options.
-                    foreach (var audience in payload.Value<JArray>(OAuthIntrospectionConstants.Claims.Audience)) {
-                        if (string.Equals(audience.Value<string>(), Options.Audience, StringComparison.Ordinal)) {
-                            return Task.FromResult(true);
-                        }
+                    var audiences = payload.Value<JArray>(OAuthIntrospectionConstants.Claims.Audience).Select(audience => audience.Value<string>());
+                    if (audiences.Intersect(Options.Audiences, StringComparer.Ordinal).Any()) {
+                        return Task.FromResult(true);
                     }
 
                     return Task.FromResult(false);
                 }
-                    
+
                 case JTokenType.String: {
                     // When the "aud" claim is a string, it must exactly match the
                     // audience registered in the introspection middleware options.
                     var audience = payload.Value<string>(OAuthIntrospectionConstants.Claims.Audience);
-                    if (string.Equals(audience, Options.Audience, StringComparison.Ordinal)) {
+                    if (Options.Audiences.Contains(audience, StringComparer.Ordinal)) {
                         return Task.FromResult(true);
                     }
 
@@ -212,8 +212,8 @@ namespace AspNet.Security.OAuth.Introspection {
 
                         continue;
                     }
-                    
-                    
+
+
                     case OAuthIntrospectionConstants.Claims.ExpiresAt: {
 #if DNXCORE50
                         // Convert the UNIX timestamp to a DateTimeOffset.
@@ -239,7 +239,7 @@ namespace AspNet.Security.OAuth.Introspection {
 
                         continue;
                     }
-                    
+
                     // Extract the scope values from the space-delimited
                     // "scope" claim and store them as individual claims.
                     // See https://tools.ietf.org/html/rfc7662#section-2.2

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
@@ -4,6 +4,7 @@
  * concerning the license and the contributors participating to this project.
  */
 
+using System.Collections.Generic;
 using System.Net.Http;
 using Microsoft.AspNet.Authentication;
 using Microsoft.Extensions.Caching.Distributed;
@@ -15,11 +16,11 @@ namespace AspNet.Security.OAuth.Introspection {
         }
 
         /// <summary>
-        /// Gets or sets the intended audience of this resource server.
+        /// Gets or sets the intended audiences of this resource server.
         /// Setting this property is recommended when the authorization
         /// server issues access tokens for multiple distinct resource servers.
         /// </summary>
-        public string Audience { get; set; }
+        public IList<string> Audiences { get; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the base address of the OAuth2/OpenID Connect server.

--- a/src/AspNet.Security.OAuth.Validation/OAuthValidationHandler.cs
+++ b/src/AspNet.Security.OAuth.Validation/OAuthValidationHandler.cs
@@ -60,7 +60,7 @@ namespace AspNet.Security.OAuth.Validation {
         protected virtual Task<bool> ValidateAudienceAsync(AuthenticationTicket ticket) {
             // If no explicit audience has been configured,
             // skip the default audience validation.
-            if (string.IsNullOrEmpty(Options.Audience)) {
+            if (Options.Audiences.Count == 0) {
                 return Task.FromResult(true);
             }
 
@@ -71,7 +71,7 @@ namespace AspNet.Security.OAuth.Validation {
             }
 
             // Ensure that the authentication ticket contains the registered audience.
-            if (!audiences.Split(' ').Contains(Options.Audience, StringComparer.Ordinal)) {
+            if (!audiences.Split(' ').Intersect(Options.Audiences, StringComparer.Ordinal).Any()) {
                 return Task.FromResult(false);
             }
 

--- a/src/AspNet.Security.OAuth.Validation/OAuthValidationOptions.cs
+++ b/src/AspNet.Security.OAuth.Validation/OAuthValidationOptions.cs
@@ -4,6 +4,7 @@
  * concerning the license and the contributors participating to this project.
  */
 
+using System.Collections.Generic;
 using Microsoft.AspNet.Authentication;
 
 namespace AspNet.Security.OAuth.Validation {
@@ -13,11 +14,11 @@ namespace AspNet.Security.OAuth.Validation {
         }
 
         /// <summary>
-        /// Gets or sets the intended audience of this resource server.
+        /// Gets or sets the intended audiences of this resource server.
         /// Setting this property is recommended when the authorization
         /// server issues access tokens for multiple distinct resource servers.
         /// </summary>
-        public string Audience { get; set; }
+        public IList<string> Audiences { get; } = new List<string>();
 
         /// <summary>
         /// Gets or sets the clock used to determine the current date/time.

--- a/test/AspNet.Security.OAuth.Introspection.Tests/OAuthIntrospectionMiddlewareTests.cs
+++ b/test/AspNet.Security.OAuth.Introspection.Tests/OAuthIntrospectionMiddlewareTests.cs
@@ -111,7 +111,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests {
         public async Task MissingAudienceCausesInvalidAuthentication() {
             // Arrange
             var server = CreateResourceServer(options => {
-                options.Audience = "http://www.fabrikam.com/";
+                options.Audiences.Add("http://www.fabrikam.com/");
                 options.ClientId = "Fabrikam";
                 options.ClientSecret = "B4657E03-D619";
             });
@@ -132,7 +132,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests {
         public async Task InvalidAudienceCausesInvalidAuthentication() {
             // Arrange
             var server = CreateResourceServer(options => {
-                options.Audience = "http://www.fabrikam.com/";
+                options.Audiences.Add("http://www.fabrikam.com/");
                 options.ClientId = "Fabrikam";
                 options.ClientSecret = "B4657E03-D619";
             });
@@ -150,10 +150,58 @@ namespace AspNet.Security.OAuth.Introspection.Tests {
         }
 
         [Fact]
+        public async Task AnyMatchingAudienceCausesSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options => {
+                options.Audiences.Add("http://www.fabrikam.com/");
+                options.Audiences.Add("http://www.google.com/");
+                options.ClientId = "Fabrikam";
+                options.ClientSecret = "B4657E03-D619";
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token-2");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
         public async Task ValidAudienceAllowsSuccessfulAuthentication() {
             // Arrange
             var server = CreateResourceServer(options => {
-                options.Audience = "http://www.fabrikam.com/";
+                options.Audiences.Add("http://www.fabrikam.com/");
+                options.ClientId = "Fabrikam";
+                options.ClientSecret = "B4657E03-D619";
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "token-3");
+
+            // Act
+            var response = await client.SendAsync(request);
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+            Assert.Equal("Fabrikam", await response.Content.ReadAsStringAsync());
+        }
+
+        [Fact]
+        public async Task MultipleMatchingAudienceCausesSuccessfulAuthentication()
+        {
+            // Arrange
+            var server = CreateResourceServer(options => {
+                options.Audiences.Add("http://www.fabrikam.com/");
+                options.Audiences.Add("http://www.google.com/");
                 options.ClientId = "Fabrikam";
                 options.ClientSecret = "B4657E03-D619";
             });


### PR DESCRIPTION
Added support for multiple valid audiences in both introspection and validation middleware. The audiences are implemented as `IList<string>` (i.e. ordered) so that a priority can be inferred for other uses (e.g. first is default).