### PR TITLE
Improve and harden the claims handling logic used by the introspection middleware and replace the legacy WS-Fed claim types by their JWT equivalent

### DIFF
--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionConfiguration.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionConfiguration.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
@@ -15,7 +15,9 @@ namespace AspNet.Security.OAuth.Introspection
             public const string ExpiresAt = "exp";
             public const string IssuedAt = "iat";
             public const string JwtId = "jti";
+            public const string Name = "name";
             public const string NotBefore = "nbf";
+            public const string Role = "role";
             public const string Scope = "scope";
             public const string Subject = "sub";
             public const string TokenType = "token_type";

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
@@ -24,6 +24,12 @@ namespace AspNet.Security.OAuth.Introspection
             public const string Username = "username";
         }
 
+        public static class ClaimValueTypes
+        {
+            public const string Json = "JSON";
+            public const string JsonArray = "JSON_ARRAY";
+        }
+
         public static class Errors
         {
             public const string InsufficientScope = "insufficient_scope";
@@ -63,6 +69,11 @@ namespace AspNet.Security.OAuth.Introspection
         public static class Schemes
         {
             public const string Bearer = "Bearer";
+        }
+
+        public static class Separators
+        {
+            public static readonly char[] Space = { ' ' };
         }
 
         public static class TokenTypes

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionError.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionError.cs
@@ -1,4 +1,10 @@
-﻿namespace AspNet.Security.OAuth.Introspection
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.Introspection
 {
     /// <summary>
     /// Represents an OAuth2 introspection error.

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionFeature.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionFeature.cs
@@ -1,4 +1,10 @@
-﻿namespace AspNet.Security.OAuth.Introspection
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.Introspection
 {
     /// <summary>
     /// Exposes the OAuth2 introspection details

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
@@ -435,7 +435,7 @@ namespace AspNet.Security.OAuth.Introspection
 
         protected virtual async Task<AuthenticationTicket> CreateTicketAsync(string token, JObject payload)
         {
-            var identity = new ClaimsIdentity(Options.AuthenticationScheme);
+            var identity = new ClaimsIdentity(Options.AuthenticationScheme, Options.NameClaimType, Options.RoleClaimType);
             var properties = new AuthenticationProperties();
 
             if (Options.SaveToken)
@@ -479,22 +479,6 @@ namespace AspNet.Security.OAuth.Introspection
                         properties.ExpiresUtc = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero) +
                                                 TimeSpan.FromSeconds((long) property.Value);
 #endif
-
-                        continue;
-                    }
-
-                    // Add the subject identifier as a new ClaimTypes.NameIdentifier claim.
-                    case OAuthIntrospectionConstants.Claims.Subject:
-                    {
-                        identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, (string) property.Value));
-
-                        continue;
-                    }
-
-                    // Add the subject identifier as a new ClaimTypes.Name claim.
-                    case OAuthIntrospectionConstants.Claims.Username:
-                    {
-                        identity.AddClaim(new Claim(ClaimTypes.Name, (string) property.Value));
 
                         continue;
                     }

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
@@ -7,6 +7,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Claims;
@@ -402,7 +404,34 @@ namespace AspNet.Security.OAuth.Introspection
                 return null;
             }
 
-            return JObject.Parse(await response.Content.ReadAsStringAsync());
+            using (var stream = await response.Content.ReadAsStreamAsync())
+            using (var reader = new JsonTextReader(new StreamReader(stream)))
+            {
+                // Limit the maximum depth to prevent stack overflow exceptions from
+                // being thrown when receiving deeply nested introspection responses.
+                reader.MaxDepth = 20;
+
+                try
+                {
+                    var payload = JObject.Load(reader);
+
+                    Logger.LogInformation("The introspection response was successfully extracted: {Response}.", payload);
+
+                    return payload;
+                }
+
+                // Swallow the known exceptions thrown by JSON.NET.
+                catch (Exception exception) when (exception is ArgumentException ||
+                                                  exception is FormatException ||
+                                                  exception is InvalidCastException ||
+                                                  exception is JsonReaderException ||
+                                                  exception is JsonSerializationException)
+                {
+                    Logger.LogError("An error occurred while deserializing the introspection response: {Exception}.", exception);
+
+                    return null;
+                }
+            }
         }
 
         protected virtual bool ValidateAudience(AuthenticationTicket ticket)
@@ -449,9 +478,19 @@ namespace AspNet.Security.OAuth.Introspection
 
             foreach (var property in payload.Properties())
             {
+                // Always exclude null values, as they can't be represented as valid claims.
+                if (property.Value.Type == JTokenType.None || property.Value.Type == JTokenType.Null)
+                {
+                    Logger.LogInformation("The '{Claim}' claim was excluded because it was null.", property.Name);
+
+                    continue;
+                }
+
+                // When the claim correspond to a protocol claim, store it as an
+                // authentication property instead of adding it as a proper claim.
                 switch (property.Name)
                 {
-                    // Ignore the unwanted claims.
+                    // Always exclude the unwanted protocol claims.
                     case OAuthIntrospectionConstants.Claims.Active:
                     case OAuthIntrospectionConstants.Claims.TokenType:
                     case OAuthIntrospectionConstants.Claims.NotBefore:
@@ -459,50 +498,80 @@ namespace AspNet.Security.OAuth.Introspection
 
                     case OAuthIntrospectionConstants.Claims.IssuedAt:
                     {
-#if NETSTANDARD1_3
-                        // Convert the UNIX timestamp to a DateTimeOffset.
-                        properties.IssuedUtc = DateTimeOffset.FromUnixTimeSeconds((long) property.Value);
-#else
+                        // Note: the iat claim must be a numeric date value.
+                        // See https://tools.ietf.org/html/rfc7662#section-2.2
+                        // and https://tools.ietf.org/html/rfc7519#section-4.1.6 for more information.
+                        if (property.Value.Type != JTokenType.Float && property.Value.Type != JTokenType.Integer)
+                        {
+                            Logger.LogWarning("The 'iat' claim was ignored because it was not a decimal value.");
+
+                            continue;
+                        }
+
                         properties.IssuedUtc = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero) +
-                                               TimeSpan.FromSeconds((long) property.Value);
-#endif
+                                               TimeSpan.FromSeconds((double) property.Value);
 
                         continue;
                     }
 
                     case OAuthIntrospectionConstants.Claims.ExpiresAt:
                     {
-#if NETSTANDARD1_3
-                        // Convert the UNIX timestamp to a DateTimeOffset.
-                        properties.ExpiresUtc = DateTimeOffset.FromUnixTimeSeconds((long) property.Value);
-#else
+                        // Note: the exp claim must be a numeric date value.
+                        // See https://tools.ietf.org/html/rfc7662#section-2.2
+                        // and https://tools.ietf.org/html/rfc7519#section-4.1.4 for more information.
+                        if (property.Value.Type != JTokenType.Float && property.Value.Type != JTokenType.Integer)
+                        {
+                            Logger.LogWarning("The 'exp' claim was ignored because it was not a decimal value.");
+
+                            continue;
+                        }
+
                         properties.ExpiresUtc = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero) +
-                                                TimeSpan.FromSeconds((long) property.Value);
-#endif
+                                                TimeSpan.FromSeconds((double) property.Value);
 
                         continue;
                     }
 
-                    // Add the token identifier as a property on the authentication ticket.
                     case OAuthIntrospectionConstants.Claims.JwtId:
                     {
+                        // Note: the jti claim must be a string value.
+                        // See https://tools.ietf.org/html/rfc7662#section-2.2
+                        // and https://tools.ietf.org/html/rfc7519#section-4.1.7 for more information.
+                        if (property.Value.Type != JTokenType.String)
+                        {
+                            Logger.LogWarning("The 'jti' claim was ignored because it was not a string value.");
+
+                            continue;
+                        }
+
                         properties.Items[OAuthIntrospectionConstants.Properties.TicketId] = (string) property;
 
                         continue;
                     }
 
-                    // Extract the scope values from the space-delimited
-                    // "scope" claim and store them as individual claims.
-                    // See https://tools.ietf.org/html/rfc7662#section-2.2
                     case OAuthIntrospectionConstants.Claims.Scope:
                     {
-                        var scopes = (string) property.Value;
+                        // Note: the scope claim must be a space-separated string value.
+                        // See https://tools.ietf.org/html/rfc7662#section-2.2
+                        // and https://tools.ietf.org/html/rfc7519#section-4.1.7 for more information.
+                        if (property.Value.Type != JTokenType.String)
+                        {
+                            Logger.LogWarning("The 'scope' claim was ignored because it was not a string value.");
 
-                        // Store the scopes list in the authentication properties.
+                            continue;
+                        }
+
+                        var scopes = ((string) property.Value).Split(
+                            OAuthIntrospectionConstants.Separators.Space,
+                            StringSplitOptions.RemoveEmptyEntries);
+
+                        // Note: the OpenID Connect extensions require storing the scopes
+                        // as an array of strings, even if there's only element in the array.
                         properties.Items[OAuthIntrospectionConstants.Properties.Scopes] =
-                            new JArray(scopes.Split(' ')).ToString(Formatting.None);
+                            new JArray(scopes).ToString(Formatting.None);
 
-                        foreach (var scope in scopes.Split(' '))
+                        // For convenience, also store the scopes as individual claims.
+                        foreach (var scope in scopes)
                         {
                             identity.AddClaim(new Claim(property.Name, scope));
                         }
@@ -510,59 +579,114 @@ namespace AspNet.Security.OAuth.Introspection
                         continue;
                     }
 
-                    // Store the audience(s) in the ticket properties.
-                    // Note: the "aud" claim may be either a list of strings or a unique string.
-                    // See https://tools.ietf.org/html/rfc7662#section-2.2
                     case OAuthIntrospectionConstants.Claims.Audience:
                     {
-                        if (property.Value.Type == JTokenType.Array)
+                        // Note: the aud claim must be either a string value or an array of strings.
+                        // See https://tools.ietf.org/html/rfc7662#section-2.2
+                        // and https://tools.ietf.org/html/rfc7519#section-4.1.4 for more information.
+                        if (property.Value.Type == JTokenType.String)
                         {
-                            var value = (JArray) property.Value;
-                            if (value == null)
+                            // Note: the OpenID Connect extensions require storing the audiences
+                            // as an array of strings, even if there's only element in the array.
+                            properties.Items[OAuthIntrospectionConstants.Properties.Audiences] =
+                                new JArray((string) property.Value).ToString(Formatting.None);
+
+                            continue;
+                        }
+
+                        else if (property.Value.Type == JTokenType.Array)
+                        {
+                            // Ensure all the array values are valid strings.
+                            var audiences = (JArray) property.Value;
+                            if (audiences.Any(audience => audience.Type != JTokenType.String))
                             {
+                                Logger.LogWarning("The 'aud' claim was ignored because it was not an array of strings.");
+
                                 continue;
                             }
 
-                            properties.Items[OAuthIntrospectionConstants.Properties.Audiences] = value.ToString(Formatting.None);
+                            properties.Items[OAuthIntrospectionConstants.Properties.Audiences] =
+                                property.Value.ToString(Formatting.None);
+
+                            continue;
                         }
 
-                        else if (property.Value.Type == JTokenType.String)
-                        {
-                            properties.Items[OAuthIntrospectionConstants.Properties.Audiences] =
-                                new JArray((string) property.Value).ToString(Formatting.None);
-                        }
+                        Logger.LogWarning("The 'aud' claim was ignored because it was not a string nor an array.");
 
                         continue;
                     }
                 }
 
+                // If the claim is not a known claim, add it as-is by
+                // trying to determine what's the best claim value type.
                 switch (property.Value.Type)
                 {
-                    // Ignore null values.
-                    case JTokenType.None:
-                    case JTokenType.Null:
+                    case JTokenType.String:
+                        identity.AddClaim(new Claim(property.Name, (string) property.Value, ClaimValueTypes.String));
+                        continue;
+
+                    case JTokenType.Integer:
+                        identity.AddClaim(new Claim(property.Name, (string) property.Value, ClaimValueTypes.Integer));
+                        continue;
+
+                    case JTokenType.Float:
+                        identity.AddClaim(new Claim(property.Name, (string) property.Value, ClaimValueTypes.Double));
                         continue;
 
                     case JTokenType.Array:
                     {
-                        foreach (var item in (JArray) property.Value)
+                        // When the claim is an array, add the corresponding items
+                        // as individual claims using the name assigned to the array.
+                        foreach (var value in (JArray) property.Value)
                         {
-                            identity.AddClaim(new Claim(property.Name, (string) item));
+                            switch (value.Type)
+                            {
+                                case JTokenType.None:
+                                case JTokenType.Null:
+                                    continue;
+
+                                case JTokenType.String:
+                                    identity.AddClaim(new Claim(property.Name, (string) value, ClaimValueTypes.String));
+                                    continue;
+
+                                case JTokenType.Integer:
+                                    identity.AddClaim(new Claim(property.Name, (string) value, ClaimValueTypes.Integer));
+                                    continue;
+
+                                case JTokenType.Float:
+                                    identity.AddClaim(new Claim(property.Name, (string) value, ClaimValueTypes.Double));
+                                    continue;
+
+                                case JTokenType.Array:
+                                {
+                                    // When the array element is itself a new array, serialize it as-it.
+                                    identity.AddClaim(new Claim(property.Name, value.ToString(Formatting.None),
+                                        OAuthIntrospectionConstants.ClaimValueTypes.JsonArray));
+
+                                    continue;
+                                }
+
+                                default:
+                                {
+                                    // When the array element doesn't correspond to a supported
+                                    // primitive type (e.g a complex object), serialize it as-it.
+                                    identity.AddClaim(new Claim(property.Name, value.ToString(Formatting.None),
+                                        OAuthIntrospectionConstants.ClaimValueTypes.Json));
+
+                                    continue;
+                                }
+                            }
                         }
 
                         continue;
                     }
 
-                    case JTokenType.String:
+                    default:
                     {
-                        identity.AddClaim(new Claim(property.Name, (string) property.Value));
-
-                        continue;
-                    }
-
-                    case JTokenType.Integer:
-                    {
-                        identity.AddClaim(new Claim(property.Name, (string) property.Value, ClaimValueTypes.Integer));
+                        // When the array element doesn't correspond to a supported
+                        // primitive type (e.g a complex object), serialize it as-it.
+                        identity.AddClaim(new Claim(property.Name, property.Value.ToString(Formatting.None),
+                            OAuthIntrospectionConstants.ClaimValueTypes.Json));
 
                         continue;
                     }

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
@@ -15,7 +15,6 @@ using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Protocols;
-using Microsoft.IdentityModel.Protocols.OpenIdConnect;
 
 namespace AspNet.Security.OAuth.Introspection
 {

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
@@ -26,6 +26,13 @@ namespace AspNet.Security.OAuth.Introspection
         }
 
         /// <summary>
+        /// Gets the intended audiences of this resource server.
+        /// Setting this property is recommended when the authorization
+        /// server issues access tokens for multiple distinct resource servers.
+        /// </summary>
+        public ISet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets or sets the absolute URL of the OAuth2/OpenID Connect server.
         /// Note: this property is ignored when <see cref="Configuration"/>
         /// or <see cref="ConfigurationManager"/> are set.
@@ -76,13 +83,6 @@ namespace AspNet.Security.OAuth.Introspection
         public string Realm { get; set; }
 
         /// <summary>
-        /// Gets the intended audiences of this resource server.
-        /// Setting this property is recommended when the authorization
-        /// server issues access tokens for multiple distinct resource servers.
-        /// </summary>
-        public ISet<string> Audiences { get; } = new HashSet<string>();
-
-        /// <summary>
         /// Gets or sets a boolean determining whether the access token should be stored in the
         /// <see cref="AuthenticationProperties"/> after a successful authentication process.
         /// </summary>
@@ -97,11 +97,14 @@ namespace AspNet.Security.OAuth.Introspection
 
         /// <summary>
         /// Gets or sets the claim type used for the name claim.
+        /// By default, the standard <see cref="OAuthIntrospectionConstants.Claims.Name"/>
+        /// claim defined by the OAuth2 introspection specification is used.
         /// </summary>
         public string NameClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Name;
 
         /// <summary>
         /// Gets or sets the claim type used for the role claim(s).
+        /// By default, <see cref="OAuthIntrospectionConstants.Claims.Role"/> is used.
         /// </summary>
         public string RoleClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Role;
 

--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
@@ -96,6 +96,16 @@ namespace AspNet.Security.OAuth.Introspection
         public bool IncludeErrorDetails { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the claim type used for the name claim.
+        /// </summary>
+        public string NameClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Name;
+
+        /// <summary>
+        /// Gets or sets the claim type used for the role claim(s).
+        /// </summary>
+        public string RoleClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Role;
+
+        /// <summary>
         /// Gets or sets the cache used to store the authentication tickets
         /// resolved from the access tokens received by the resource server.
         /// </summary>

--- a/src/AspNet.Security.OAuth.Validation/OAuthValidationConstants.cs
+++ b/src/AspNet.Security.OAuth.Validation/OAuthValidationConstants.cs
@@ -11,6 +11,7 @@ namespace AspNet.Security.OAuth.Validation
         public static class Claims
         {
             public const string Scope = "scope";
+            public const string Subject = "subject";
         }
 
         public static class Errors

--- a/src/AspNet.Security.OAuth.Validation/OAuthValidationError.cs
+++ b/src/AspNet.Security.OAuth.Validation/OAuthValidationError.cs
@@ -1,4 +1,10 @@
-﻿namespace AspNet.Security.OAuth.Validation
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.Validation
 {
     /// <summary>
     /// Represents an OAuth2 validation error.

--- a/src/AspNet.Security.OAuth.Validation/OAuthValidationFeature.cs
+++ b/src/AspNet.Security.OAuth.Validation/OAuthValidationFeature.cs
@@ -1,4 +1,10 @@
-﻿namespace AspNet.Security.OAuth.Validation
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+namespace AspNet.Security.OAuth.Validation
 {
     /// <summary>
     /// Exposes the OAuth2 validation details

--- a/src/AspNet.Security.OAuth.Validation/OAuthValidationOptions.cs
+++ b/src/AspNet.Security.OAuth.Validation/OAuthValidationOptions.cs
@@ -4,6 +4,7 @@
  * concerning the license and the contributors participating to this project.
  */
 
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Builder;
@@ -26,7 +27,7 @@ namespace AspNet.Security.OAuth.Validation
         /// Setting this property is recommended when the authorization
         /// server issues access tokens for multiple distinct resource servers.
         /// </summary>
-        public ISet<string> Audiences { get; } = new HashSet<string>();
+        public ISet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the optional "realm" value returned to

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionConfiguration.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionConfiguration.cs
@@ -1,4 +1,10 @@
-﻿using System;
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using JetBrains.Annotations;

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
@@ -24,6 +24,12 @@ namespace Owin.Security.OAuth.Introspection
             public const string Username = "username";
         }
 
+        public static class ClaimValueTypes
+        {
+            public const string Json = "JSON";
+            public const string JsonArray = "JSON_ARRAY";
+        }
+
         public static class Errors
         {
             public const string InsufficientScope = "insufficient_scope";
@@ -69,6 +75,11 @@ namespace Owin.Security.OAuth.Introspection
         public static class Schemes
         {
             public const string Bearer = "Bearer";
+        }
+
+        public static class Separators
+        {
+            public static readonly char[] Space = { ' ' };
         }
 
         public static class TokenTypes

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionConstants.cs
@@ -15,7 +15,9 @@ namespace Owin.Security.OAuth.Introspection
             public const string ExpiresAt = "exp";
             public const string IssuedAt = "iat";
             public const string JwtId = "jti";
+            public const string Name = "name";
             public const string NotBefore = "nbf";
+            public const string Role = "role";
             public const string Scope = "scope";
             public const string Subject = "sub";
             public const string TokenType = "token_type";

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionError.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionError.cs
@@ -1,4 +1,10 @@
-﻿namespace Owin.Security.OAuth.Introspection
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+namespace Owin.Security.OAuth.Introspection
 {
     /// <summary>
     /// Represents an OAuth2 introspection error.

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionHandler.cs
@@ -424,7 +424,7 @@ namespace Owin.Security.OAuth.Introspection
 
         protected virtual async Task<AuthenticationTicket> CreateTicketAsync(string token, JObject payload)
         {
-            var identity = new ClaimsIdentity(Options.AuthenticationType);
+            var identity = new ClaimsIdentity(Options.AuthenticationType, Options.NameClaimType, Options.RoleClaimType);
             var properties = new AuthenticationProperties();
 
             if (Options.SaveToken)

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
@@ -28,7 +28,7 @@ namespace Owin.Security.OAuth.Introspection
             [NotNull] OAuthIntrospectionOptions options)
             : base(next, options)
         {
-            if (string.IsNullOrEmpty(options.ClientId) ||string.IsNullOrEmpty(options.ClientSecret))
+            if (string.IsNullOrEmpty(options.ClientId) || string.IsNullOrEmpty(options.ClientSecret))
             {
                 throw new ArgumentException("Client credentials must be configured.", nameof(options));
             }

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
@@ -95,6 +95,16 @@ namespace Owin.Security.OAuth.Introspection
         public bool IncludeErrorDetails { get; set; } = true;
 
         /// <summary>
+        /// Gets or sets the claim type used for the name claim.
+        /// </summary>
+        public string NameClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Name;
+
+        /// <summary>
+        /// Gets or sets the claim type used for the role claim(s).
+        /// </summary>
+        public string RoleClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Role;
+
+        /// <summary>
         /// Gets or sets the cache used to store the authentication tickets
         /// resolved from the access tokens received by the resource server.
         /// </summary>

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
@@ -32,6 +32,13 @@ namespace Owin.Security.OAuth.Introspection
         public Uri Authority { get; set; }
 
         /// <summary>
+        /// Gets the intended audiences of this resource server.
+        /// Setting this property is recommended when the authorization
+        /// server issues access tokens for multiple distinct resource servers.
+        /// </summary>
+        public ISet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
+
+        /// <summary>
         /// Gets or sets the URL of the OAuth2/OpenID Connect server discovery endpoint.
         /// When the URL is relative, <see cref="Authority"/> must be set and absolute.
         /// Note: this property is ignored when <see cref="Configuration"/>
@@ -75,13 +82,6 @@ namespace Owin.Security.OAuth.Introspection
         public string Realm { get; set; }
 
         /// <summary>
-        /// Gets the intended audiences of this resource server.
-        /// Setting this property is recommended when the authorization
-        /// server issues access tokens for multiple distinct resource servers.
-        /// </summary>
-        public ISet<string> Audiences { get; } = new HashSet<string>();
-
-        /// <summary>
         /// Gets or sets a boolean determining whether the access token should be stored in the
         /// <see cref="AuthenticationProperties"/> after a successful authentication process.
         /// </summary>
@@ -96,11 +96,14 @@ namespace Owin.Security.OAuth.Introspection
 
         /// <summary>
         /// Gets or sets the claim type used for the name claim.
+        /// By default, the standard <see cref="OAuthIntrospectionConstants.Claims.Name"/>
+        /// claim defined by the OAuth2 introspection specification is used.
         /// </summary>
         public string NameClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Name;
 
         /// <summary>
         /// Gets or sets the claim type used for the role claim(s).
+        /// By default, <see cref="OAuthIntrospectionConstants.Claims.Role"/> is used.
         /// </summary>
         public string RoleClaimType { get; set; } = OAuthIntrospectionConstants.Claims.Role;
 

--- a/src/Owin.Security.OAuth.Validation/OAuthValidationConstants.cs
+++ b/src/Owin.Security.OAuth.Validation/OAuthValidationConstants.cs
@@ -11,6 +11,7 @@ namespace Owin.Security.OAuth.Validation
         public static class Claims
         {
             public const string Scope = "scope";
+            public const string Subject = "subject";
         }
 
         public static class Errors

--- a/src/Owin.Security.OAuth.Validation/OAuthValidationError.cs
+++ b/src/Owin.Security.OAuth.Validation/OAuthValidationError.cs
@@ -1,4 +1,10 @@
-﻿namespace Owin.Security.OAuth.Validation
+﻿/*
+ * Licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ * See https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions for more information
+ * concerning the license and the contributors participating to this project.
+ */
+
+namespace Owin.Security.OAuth.Validation
 {
     /// <summary>
     /// Represents an OAuth2 validation error.

--- a/src/Owin.Security.OAuth.Validation/OAuthValidationOptions.cs
+++ b/src/Owin.Security.OAuth.Validation/OAuthValidationOptions.cs
@@ -4,6 +4,7 @@
  * concerning the license and the contributors participating to this project.
  */
 
+using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.Extensions.Logging;
@@ -25,7 +26,7 @@ namespace Owin.Security.OAuth.Validation
         /// Setting this property is recommended when the authorization
         /// server issues access tokens for multiple distinct resource servers.
         /// </summary>
-        public ISet<string> Audiences { get; } = new HashSet<string>();
+        public ISet<string> Audiences { get; } = new HashSet<string>(StringComparer.Ordinal);
 
         /// <summary>
         /// Gets or sets the optional "realm" value returned to

--- a/test/AspNet.Security.OAuth.Introspection.Tests/OAuthIntrospectionHandlerTests.cs
+++ b/test/AspNet.Security.OAuth.Introspection.Tests/OAuthIntrospectionHandlerTests.cs
@@ -131,8 +131,8 @@ namespace AspNet.Security.OAuth.Introspection.Tests
             // Arrange
             var server = CreateResourceServer(options =>
             {
+                options.Audiences.Add("http://www.contoso.com/");
                 options.Audiences.Add("http://www.fabrikam.com/");
-                options.Audiences.Add("http://www.google.com/");
             });
 
             var client = server.CreateClient();
@@ -227,24 +227,17 @@ namespace AspNet.Security.OAuth.Introspection.Tests
             var response = await client.SendAsync(request);
 
             var ticket = JObject.Parse(await response.Content.ReadAsStringAsync());
-            var claims = from claim in ticket.Value<JArray>("Claims")
-                         select new
-                         {
-                             Type = claim.Value<string>(nameof(Claim.Type)),
-                             Value = claim.Value<string>(nameof(Claim.Value))
-                         };
+            var claims = ticket.Value<JArray>("Claims").Select(claim => new
+            {
+                Type = claim.Value<string>(nameof(Claim.Type)),
+                Value = claim.Value<string>(nameof(Claim.Value))
+            });
 
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-
-            Assert.Contains(claims, claim => claim.Type == ClaimTypes.NameIdentifier &&
-                                             claim.Value == "Fabrikam");
-
-            Assert.Contains(claims, claim => claim.Type == OAuthIntrospectionConstants.Claims.Scope &&
-                                             claim.Value == "C54A8F5E-0387-43F4-BA43-FD4B50DC190D");
-
-            Assert.Contains(claims, claim => claim.Type == OAuthIntrospectionConstants.Claims.Scope &&
-                                             claim.Value == "5C57E3BD-9EFB-4224-9AB8-C8C5E009FFD7");
+            Assert.Contains(new { Type = OAuthIntrospectionConstants.Claims.Subject, Value = "Fabrikam" }, claims);
+            Assert.Contains(new { Type = OAuthIntrospectionConstants.Claims.Scope, Value = "openid" }, claims);
+            Assert.Contains(new { Type = OAuthIntrospectionConstants.Claims.Scope, Value = "profile" }, claims);
         }
 
         [Fact]
@@ -394,7 +387,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests
                 options.Events.OnRetrieveToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                    identity.AddClaim(new Claim(OAuthIntrospectionConstants.Claims.Subject, "Fabrikam"));
 
                     context.Ticket = new AuthenticationTicket(
                         new ClaimsPrincipal(identity),
@@ -482,7 +475,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests
                 options.Events.OnValidateToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Contoso"));
+                    identity.AddClaim(new Claim(OAuthIntrospectionConstants.Claims.Subject, "Contoso"));
 
                     context.Ticket = new AuthenticationTicket(
                         new ClaimsPrincipal(identity),
@@ -517,7 +510,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests
                 options.Events.OnValidateToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Contoso"));
+                    identity.AddClaim(new Claim(OAuthIntrospectionConstants.Claims.Subject, "Contoso"));
 
                     context.Ticket = new AuthenticationTicket(
                         new ClaimsPrincipal(identity),
@@ -695,6 +688,8 @@ namespace AspNet.Security.OAuth.Introspection.Tests
             var builder = new WebHostBuilder();
             builder.UseEnvironment("Testing");
 
+            builder.ConfigureLogging(options => options.AddDebug());
+
             builder.ConfigureServices(services =>
             {
                 services.AddAuthentication();
@@ -768,7 +763,13 @@ namespace AspNet.Security.OAuth.Introspection.Tests
                         return context.Authentication.ChallengeAsync();
                     }
 
-                    return context.Response.WriteAsync(context.User.FindFirst(ClaimTypes.NameIdentifier)?.Value);
+                    var subject = context.User.FindFirst(OAuthIntrospectionConstants.Claims.Subject)?.Value;
+                    if (string.IsNullOrEmpty(subject))
+                    {
+                        return context.Authentication.ChallengeAsync();
+                    }
+
+                    return context.Response.WriteAsync(subject);
                 });
             });
 
@@ -854,8 +855,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests
                                 payload[OAuthIntrospectionConstants.Claims.Active] = true;
                                 payload[OAuthIntrospectionConstants.Claims.JwtId] = "jwt-token-identifier";
                                 payload[OAuthIntrospectionConstants.Claims.Subject] = "Fabrikam";
-                                payload[OAuthIntrospectionConstants.Claims.Scope] =
-                                    "C54A8F5E-0387-43F4-BA43-FD4B50DC190D 5C57E3BD-9EFB-4224-9AB8-C8C5E009FFD7";
+                                payload[OAuthIntrospectionConstants.Claims.Scope] = "openid profile";
 
                                 break;
                             }
@@ -865,7 +865,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests
                                 payload[OAuthIntrospectionConstants.Claims.Active] = true;
                                 payload[OAuthIntrospectionConstants.Claims.JwtId] = "jwt-token-identifier";
                                 payload[OAuthIntrospectionConstants.Claims.Subject] = "Fabrikam";
-                                payload[OAuthIntrospectionConstants.Claims.Audience] = "http://www.google.com/";
+                                payload[OAuthIntrospectionConstants.Claims.Audience] = "http://www.contoso.com/";
 
                                 break;
                             }
@@ -877,7 +877,7 @@ namespace AspNet.Security.OAuth.Introspection.Tests
                                 payload[OAuthIntrospectionConstants.Claims.Subject] = "Fabrikam";
                                 payload[OAuthIntrospectionConstants.Claims.Audience] = JArray.FromObject(new[]
                                 {
-                                    "http://www.google.com/", "http://www.fabrikam.com/"
+                                    "http://www.contoso.com/", "http://www.fabrikam.com/"
                                 });
 
                                 break;

--- a/test/AspNet.Security.OAuth.Validation.Tests/OAuthValidationHandlerTests.cs
+++ b/test/AspNet.Security.OAuth.Validation.Tests/OAuthValidationHandlerTests.cs
@@ -136,8 +136,8 @@ namespace AspNet.Security.OAuth.Validation.Tests
             // Arrange
             var server = CreateResourceServer(options =>
             {
-                options.Audiences.Add("http://www.unknown.com/");
-                options.Audiences.Add("http://www.google.com/");
+                options.Audiences.Add("http://www.contoso.com/");
+                options.Audiences.Add("http://www.fabrikam.com/");
             });
 
             var client = server.CreateClient();
@@ -159,8 +159,8 @@ namespace AspNet.Security.OAuth.Validation.Tests
             // Arrange
             var server = CreateResourceServer(options =>
             {
+                options.Audiences.Add("http://www.contoso.com/");
                 options.Audiences.Add("http://www.fabrikam.com/");
-                options.Audiences.Add("http://www.google.com/");
             });
 
             var client = server.CreateClient();
@@ -217,7 +217,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            Assert.Contains(claims, claim => claim.Type == ClaimTypes.NameIdentifier &&
+            Assert.Contains(claims, claim => claim.Type == OAuthValidationConstants.Claims.Subject &&
                                              claim.Value == "Fabrikam");
 
             Assert.Contains(claims, claim => claim.Type == OAuthValidationConstants.Claims.Scope &&
@@ -374,7 +374,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
                 options.Events.OnRetrieveToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                     context.Ticket = new AuthenticationTicket(
                         new ClaimsPrincipal(identity),
@@ -462,7 +462,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
                 options.Events.OnValidateToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Contoso"));
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Contoso"));
 
                     context.Ticket = new AuthenticationTicket(
                         new ClaimsPrincipal(identity),
@@ -497,7 +497,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
                 options.Events.OnValidateToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationScheme);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Contoso"));
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Contoso"));
 
                     context.Ticket = new AuthenticationTicket(
                         new ClaimsPrincipal(identity),
@@ -679,7 +679,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties();
 
@@ -691,7 +691,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties();
                       properties.Items[OAuthValidationConstants.Properties.Scopes] =
@@ -705,11 +705,11 @@ namespace AspNet.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties(new Dictionary<string, string>
                       {
-                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.google.com/""]"
+                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.contoso.com/""]"
                       });
 
                       return new AuthenticationTicket(new ClaimsPrincipal(identity),
@@ -720,11 +720,11 @@ namespace AspNet.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties(new Dictionary<string, string>
                       {
-                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.google.com/"",""http://www.fabrikam.com/""]"
+                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.contoso.com/"",""http://www.fabrikam.com/""]"
                       });
 
                       return new AuthenticationTicket(new ClaimsPrincipal(identity),
@@ -735,7 +735,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties();
                       properties.ExpiresUtc = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
@@ -818,7 +818,7 @@ namespace AspNet.Security.OAuth.Validation.Tests
                         return context.Authentication.ChallengeAsync();
                     }
 
-                    var identifier = context.User.FindFirst(ClaimTypes.NameIdentifier).Value;
+                    var identifier = context.User.FindFirst(OAuthValidationConstants.Claims.Subject).Value;
                     return context.Response.WriteAsync(identifier);
                 });
             });

--- a/test/Owin.Security.OAuth.Validation.Tests/OAuthValidationHandlerTests.cs
+++ b/test/Owin.Security.OAuth.Validation.Tests/OAuthValidationHandlerTests.cs
@@ -129,8 +129,8 @@ namespace Owin.Security.OAuth.Validation.Tests
             // Arrange
             var server = CreateResourceServer(options =>
             {
+                options.Audiences.Add("http://www.contoso.com/");
                 options.Audiences.Add("http://www.fabrikam.com/");
-                options.Audiences.Add("http://www.google.com/");
             });
 
             var client = server.HttpClient;
@@ -152,8 +152,8 @@ namespace Owin.Security.OAuth.Validation.Tests
             // Arrange
             var server = CreateResourceServer(options =>
             {
+                options.Audiences.Add("http://www.contoso.com/");
                 options.Audiences.Add("http://www.fabrikam.com/");
-                options.Audiences.Add("http://www.google.com/");
             });
 
             var client = server.HttpClient;
@@ -212,7 +212,7 @@ namespace Owin.Security.OAuth.Validation.Tests
             // Assert
             Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-            Assert.Contains(claims, claim => claim.Type == ClaimTypes.NameIdentifier &&
+            Assert.Contains(claims, claim => claim.Type == OAuthValidationConstants.Claims.Subject &&
                                              claim.Value == "Fabrikam");
 
             Assert.Contains(claims, claim => claim.Type == OAuthValidationConstants.Claims.Scope &&
@@ -369,7 +369,7 @@ namespace Owin.Security.OAuth.Validation.Tests
                 options.Events.OnRetrieveToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationType);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                     context.Ticket = new AuthenticationTicket(identity, new AuthenticationProperties());
 
@@ -454,7 +454,7 @@ namespace Owin.Security.OAuth.Validation.Tests
                 options.Events.OnValidateToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationType);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Contoso"));
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Contoso"));
 
                     context.Ticket = new AuthenticationTicket(identity, new AuthenticationProperties());
                     context.HandleResponse();
@@ -485,7 +485,7 @@ namespace Owin.Security.OAuth.Validation.Tests
                 options.Events.OnValidateToken = context =>
                 {
                     var identity = new ClaimsIdentity(context.Options.AuthenticationType);
-                    identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Contoso"));
+                    identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Contoso"));
 
                     context.Ticket = new AuthenticationTicket(identity, new AuthenticationProperties());
                     context.HandleResponse();
@@ -663,7 +663,7 @@ namespace Owin.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       return new AuthenticationTicket(identity, new AuthenticationProperties());
                   });
@@ -672,7 +672,7 @@ namespace Owin.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties();
                       properties.Dictionary[OAuthValidationConstants.Properties.Scopes] =
@@ -685,11 +685,11 @@ namespace Owin.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties(new Dictionary<string, string>
                       {
-                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.google.com/""]"
+                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.contoso.com/""]"
                       });
 
                       return new AuthenticationTicket(identity, properties);
@@ -699,11 +699,11 @@ namespace Owin.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties(new Dictionary<string, string>
                       {
-                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.google.com/"",""http://www.fabrikam.com/""]"
+                          [OAuthValidationConstants.Properties.Audiences] = @"[""http://www.contoso.com/"",""http://www.fabrikam.com/""]"
                       });
 
                       return new AuthenticationTicket(identity, properties);
@@ -713,7 +713,7 @@ namespace Owin.Security.OAuth.Validation.Tests
                   .Returns(delegate
                   {
                       var identity = new ClaimsIdentity(OAuthValidationDefaults.AuthenticationScheme);
-                      identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, "Fabrikam"));
+                      identity.AddClaim(new Claim(OAuthValidationConstants.Claims.Subject, "Fabrikam"));
 
                       var properties = new AuthenticationProperties();
                       properties.ExpiresUtc = DateTimeOffset.UtcNow - TimeSpan.FromDays(1);
@@ -787,7 +787,7 @@ namespace Owin.Security.OAuth.Validation.Tests
                         return Task.FromResult(0);
                     }
 
-                    var identifier = context.Authentication.User.FindFirst(ClaimTypes.NameIdentifier).Value;
+                    var identifier = context.Authentication.User.FindFirst(OAuthValidationConstants.Claims.Subject).Value;
                     return context.Response.WriteAsync(identifier);
                 });
             });


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions/issues/52 and https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions/issues/53.