### PR TITLE
Update the Data Protection purposes to force the validation middleware to reject access tokens serialized using the old properties format

### DIFF
--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
@@ -48,7 +48,7 @@ namespace AspNet.Security.OAuth.Introspection
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OAuthIntrospectionMiddleware),
-                    Options.AuthenticationScheme, "Access_Token", "v1");
+                    nameof(Options.AccessTokenFormat), Options.AuthenticationScheme);
 
                 Options.AccessTokenFormat = new TicketDataFormat(protector);
             }

--- a/src/AspNet.Security.OAuth.Validation/OAuthValidationMiddleware.cs
+++ b/src/AspNet.Security.OAuth.Validation/OAuthValidationMiddleware.cs
@@ -36,9 +36,9 @@ namespace AspNet.Security.OAuth.Validation
 
             if (Options.AccessTokenFormat == null)
             {
-                // Note: the following purposes must match the values used by ASOS.
+                // Note: the following purposes must match the ones used by the OpenID Connect server middleware.
                 var protector = Options.DataProtectionProvider.CreateProtector(
-                    "OpenIdConnectServerMiddleware", "ASOS", "Access_Token", "v1");
+                    "OpenIdConnectServerMiddleware", nameof(Options.AccessTokenFormat), "ASOS");
 
                 Options.AccessTokenFormat = new TicketDataFormat(protector);
             }

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionMiddleware.cs
@@ -57,7 +57,7 @@ namespace Owin.Security.OAuth.Introspection
             {
                 var protector = Options.DataProtectionProvider.CreateProtector(
                     nameof(OAuthIntrospectionMiddleware),
-                    Options.AuthenticationType, "Access_Token", "v1");
+                    nameof(Options.AccessTokenFormat), Options.AuthenticationType);
 
                 options.AccessTokenFormat = new AspNetTicketDataFormat(new DataProtectorShim(protector));
             }

--- a/src/Owin.Security.OAuth.Validation/OAuthValidationMiddleware.cs
+++ b/src/Owin.Security.OAuth.Validation/OAuthValidationMiddleware.cs
@@ -46,9 +46,9 @@ namespace Owin.Security.OAuth.Validation
 
             if (options.AccessTokenFormat == null)
             {
-                // Note: the following purposes must match the ones used by ASOS.
-                var protector = options.DataProtectionProvider.CreateProtector(
-                    "OpenIdConnectServerMiddleware", "ASOS", "Access_Token", "v1");
+                // Note: the following purposes must match the ones used by the OpenID Connect server middleware.
+                var protector = Options.DataProtectionProvider.CreateProtector(
+                    "OpenIdConnectServerMiddleware", nameof(Options.AccessTokenFormat), "ASOS");
 
                 options.AccessTokenFormat = new AspNetTicketDataFormat(new DataProtectorShim(protector));
             }


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions/issues/60.