### PR TITLE
Add a .nuspec file to ensure framework assemblies are correctly added to the OWIN introspection package

### DIFF
--- a/src/Owin.Security.OAuth.Introspection/Owin.Security.OAuth.Introspection.csproj
+++ b/src/Owin.Security.OAuth.Introspection/Owin.Security.OAuth.Introspection.csproj
@@ -22,7 +22,40 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Reference Include="System.IdentityModel" />
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+
+  <!--
+    Warning: due to a design change in NuGet, framework assemblies (represented as 'References' nodes in this file)
+    are no longer automatically added to the .nuspec file published with this package. To avoid a breaking change that
+    would force final users to reference the framework assemblies in their own project, automatic .nuspec generation
+    is disabled and replaced by a custom Owin.Security.OAuth.Introspection.nuspec file that explicitly references
+    them under the 'frameworkAssemblies' node. See https://github.com/NuGet/Home/issues/4853 for more information.
+  -->
+
+  <PropertyGroup>
+    <NuSpecFile>$(MSBuildThisFileDirectory)$(MSBuildProjectName).nuspec</NuSpecFile>
+  </PropertyGroup>
+
+  <Target Name="SetPackageProperties" BeforeTargets="GenerateNuspec">
+    <PropertyGroup>
+      <NuspecProperties>$(NuspecProperties);id=$(PackageId)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);version=$(PackageVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);authors=$(Authors)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);requireLicenseAcceptance=$(PackageRequireLicenseAcceptance)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);licenseUrl=$(PackageLicenseUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);projectUrl=$(PackageProjectUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);iconUrl=$(PackageIconUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);description=$(Description)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);tags=$(PackageTags.Replace(";"," "))</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);repositoryType=$(RepositoryType)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);repositoryUrl=$(RepositoryUrl)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);configuration=$(Configuration)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);aspNetCoreVersion=$(AspNetCoreVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);jsonNetVersion=$(JsonNetVersion)</NuspecProperties>
+      <NuspecProperties>$(NuspecProperties);identityModelVersion=$(IdentityModelVersion)</NuspecProperties>
+    </PropertyGroup>
+  </Target>
 
 </Project>

--- a/src/Owin.Security.OAuth.Introspection/Owin.Security.OAuth.Introspection.nuspec
+++ b/src/Owin.Security.OAuth.Introspection/Owin.Security.OAuth.Introspection.nuspec
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>$id$</id>
+    <version>$version$</version>
+    <authors>$authors$</authors>
+    <owners>$authors$</owners>
+    <requireLicenseAcceptance>$requireLicenseAcceptance$</requireLicenseAcceptance>
+    <licenseUrl>$licenseUrl$</licenseUrl>
+    <projectUrl>$projectUrl$</projectUrl>
+    <iconUrl>$iconUrl$</iconUrl>
+    <description>$description$</description>
+    <tags>$tags$</tags>
+    <repository type="$repositoryType$" url="$repositoryUrl$" />
+    <dependencies>
+      <group targetFramework=".NETFramework4.5.1">
+        <dependency id="Microsoft.Owin.Security.Interop" version="$aspNetCoreVersion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Caching.Memory" version="$aspNetCoreVersion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.Extensions.Logging" version="$aspNetCoreVersion$" exclude="Build,Analyzers" />
+        <dependency id="Newtonsoft.Json" version="$jsonNetVersion$" exclude="Build,Analyzers" />
+        <dependency id="Microsoft.IdentityModel.Protocol.Extensions" version="$identityModelVersion$" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+    <frameworkAssemblies>
+      <frameworkAssembly assemblyName="System.IdentityModel" targetFramework=".NETFramework4.5.1" />
+      <frameworkAssembly assemblyName="System.Net.Http" targetFramework=".NETFramework4.5.1" />
+    </frameworkAssemblies>
+  </metadata>
+  <files>
+    <file src="bin\$configuration$\net451\$id$.dll" target="lib\net451" />
+    <file src="bin\$configuration$\net451\$id$.xml" target="lib\net451" />
+  </files>
+</package>


### PR DESCRIPTION
Fixes https://github.com/aspnet-contrib/AspNet.Security.OAuth.Extensions/issues/65.