### PR TITLE
Add HttpHeaders from request to Introspection request.

### DIFF
--- a/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
+++ b/src/AspNet.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
@@ -140,6 +140,35 @@ namespace AspNet.Security.OAuth.Introspection
         }
 
         /// <summary>
+        /// Copy Http Headers that match the provided values from the request being authenticated to the Introspection request.
+        /// </summary>
+        /// <param name="exactMatches">List of strings that are matched to the Http Headers exactly.</param>
+        /// <param name="prefixes">List of strings that Http Headers are compared to, e.g. "X-" for X-Forwarded or X-Correlation-Id.</param>
+        public void SetValuesToMatchFromRequestHttpHeaders(string[] exactMatches, string[] prefixes)
+        {
+            IncludeHttpHeadersFromRequest = (exactMatches?.Length > 0 || prefixes?.Length > 0);
+
+            MatchingHttpHeadersPrefixes = prefixes ?? new string[0];
+            MatchingHttpHeadersExact = exactMatches ?? new string[0];
+        }
+
+        /// <summary>
+        /// Property that returns whether Http Headers that match either the exact or prefix values will be copied or not.  To set
+        /// this property to false, call method SetValuesToMatchFromRequestHttpHeaders with an empty string.
+        /// </summary>
+        public bool IncludeHttpHeadersFromRequest { get; private set; }
+
+        /// <summary>
+        /// Property that returns the prefix to use to match Http Headers.
+        /// </summary>
+        public string[] MatchingHttpHeadersPrefixes { get; private set; }
+
+        /// <summary>
+        /// Property that returns the exatc matches to use when matching Http Headers.
+        /// </summary>
+        public string[] MatchingHttpHeadersExact { get; private set; }
+
+        /// <summary>
         /// Gets or sets the HTTP client used to communicate with the remote OAuth2 server.
         /// </summary>
         public HttpClient HttpClient { get; set; }

--- a/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
+++ b/src/Owin.Security.OAuth.Introspection/OAuthIntrospectionOptions.cs
@@ -139,6 +139,35 @@ namespace Owin.Security.OAuth.Introspection
         public OAuthIntrospectionEvents Events { get; set; } = new OAuthIntrospectionEvents();
 
         /// <summary>
+        /// Copy Http Headers that match the provided values from the request being authenticated to the Introspection request.
+        /// </summary>
+        /// <param name="exactMatches">List of strings that are matched to the Http Headers exactly.</param>
+        /// <param name="prefixes">List of strings that Http Headers are compared to, e.g. "X-" for X-Forwarded or X-Correlation-Id.</param>
+        public void SetValuesToMatchFromRequestHttpHeaders(string[] exactMatches, string[] prefixes)
+        {
+            IncludeHttpHeadersFromRequest = (exactMatches?.Length > 0 || prefixes?.Length > 0);
+
+            MatchingHttpHeadersPrefixes = prefixes ?? new string[0];
+            MatchingHttpHeadersExact = exactMatches ?? new string[0];
+        }
+
+        /// <summary>
+        /// Property that returns whether matching Http Headers will be copied or not.  To set
+        /// this property to false, call method SetValuesToMatchFromRequestHttpHeaders with an empty string.
+        /// </summary>
+        public bool IncludeHttpHeadersFromRequest { get; private set; }
+
+        /// <summary>
+        /// Property that returns the prefix to use to match Http Headers.
+        /// </summary>
+        public string[] MatchingHttpHeadersPrefixes { get; private set; }
+
+        /// <summary>
+        /// Property that returns the exatc matches to use when matching Http Headers.
+        /// </summary>
+        public string[] MatchingHttpHeadersExact { get; private set; }
+
+        /// <summary>
         /// Gets or sets the HTTP client used to communicate with the remote OAuth2 server.
         /// </summary>
         public HttpClient HttpClient { get; set; }

--- a/test/AspNet.Security.OAuth.Introspection.Tests/OAuthIntrospectionHandlerTests.cs
+++ b/test/AspNet.Security.OAuth.Introspection.Tests/OAuthIntrospectionHandlerTests.cs
@@ -800,6 +800,310 @@ namespace AspNet.Security.OAuth.Introspection.Tests
             Assert.Equal(header, response.Headers.WwwAuthenticate.ToString());
         }
 
+        [Fact]
+        public async Task HandleAuthenticateAsync_CopyMatchingHttpHeaders_NotSet()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var forwardedFor = "1.1.1.1";
+            var xCorrelationId = "X-Correlation-Id";
+            var xForwardedFor = "X-Forwarded-For";
+            var someHttpHeader = "Some-Http-Header";
+
+            var server = CreateResourceServer(options =>
+            {
+                options.Events.OnSendIntrospectionRequest = context =>
+                {
+                    // Assert
+                    var headers = context.Request.Headers;
+                    var keys = headers.Select(x => x.Key).ToArray();
+
+                    Assert.DoesNotContain(new[] { xCorrelationId, xForwardedFor, someHttpHeader }, (x => keys.Contains(x)));
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+            request.Headers.Add(xCorrelationId, new List<string> { correlationId });
+            request.Headers.Add(xForwardedFor, new List<string> { forwardedFor });
+            request.Headers.Add(someHttpHeader, new List<string> { "header-value" });
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_CopyMatchingHttpHeaders_DoesNotContainNonMatchedHeaders()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var forwardedFor = "1.1.1.1";
+            var xCorrelationId = "X-Correlation-Id";
+            var xForwardedFor = "X-Forwarded-For";
+            var someHttpHeader = "Some-Http-Header";
+
+            var server = CreateResourceServer(options =>
+            {
+                options.SetValuesToMatchFromRequestHttpHeaders(null, new[] { "X-" });
+                options.Events.OnSendIntrospectionRequest = context =>
+                {
+                    // Assert
+                    var headers = context.Request.Headers;
+                    var keys = headers.Select(x => x.Key).ToArray();
+
+                    Assert.DoesNotContain(new[] { someHttpHeader }, (x => keys.Contains(x)));
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+            request.Headers.Add(xCorrelationId, new List<string> { correlationId });
+            request.Headers.Add(xForwardedFor, new List<string> { forwardedFor });
+            request.Headers.Add(someHttpHeader, new List<string> { "header-value" });
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_CopyMatchingHttpHeaders_UsingMulitplePrefixes()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var forwardedFor = "1.1.1.1";
+            var headerPrefixX = "X-";
+            var headerPrefixY = "Y-";
+            var xCorrelationId = "X-Correlation-Id";
+            var xForwardedFor = "Y-Forwarded-For";
+            var someHttpHeader = "Some-Http-Header";
+
+            var server = CreateResourceServer(options =>
+            {
+                options.SetValuesToMatchFromRequestHttpHeaders(null, new[] { headerPrefixX, headerPrefixY });
+                options.Events.OnSendIntrospectionRequest = context =>
+                {
+                    // Assert
+                    var headers = context.Request.Headers;
+                    var keys = headers.Select(x => x.Key).ToArray();
+
+                    Assert.Contains(new[] { xCorrelationId, xForwardedFor }, (x => keys.Contains(x)));
+                    Assert.Contains(correlationId, headers.Single(x => x.Key.Equals(xCorrelationId, StringComparison.Ordinal)).Value);
+                    Assert.Contains(forwardedFor, headers.Single(x => x.Key.Equals(xForwardedFor, StringComparison.Ordinal)).Value);
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+            request.Headers.Add(xCorrelationId, new List<string> { correlationId });
+            request.Headers.Add(xForwardedFor, new List<string> { forwardedFor });
+            request.Headers.Add(someHttpHeader, new List<string> { "header-value" });
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_CopyMatchingHttpHeaders_UsingSinglePrefix()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var forwardedFor = "1.1.1.1";
+            var xCorrelationId = "X-Correlation-Id";
+            var xForwardedFor = "X-Forwarded-For";
+            var headerPrefix = "X-";
+
+            var server = CreateResourceServer(options =>
+            {
+                options.SetValuesToMatchFromRequestHttpHeaders(null, new[] { headerPrefix });
+                options.Events.OnSendIntrospectionRequest = context =>
+                {
+                    // Assert
+                    var headers = context.Request.Headers;
+                    var keys = headers.Select(x => x.Key).ToArray();
+
+                    Assert.Contains(new[] { xCorrelationId, xForwardedFor }, (x => keys.Contains(x)));
+                    Assert.Contains(correlationId, headers.Single(x => x.Key.Equals(xCorrelationId, StringComparison.Ordinal)).Value);
+                    Assert.Contains(forwardedFor, headers.Single(x => x.Key.Equals(xForwardedFor, StringComparison.Ordinal)).Value);
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+            request.Headers.Add(xCorrelationId, new List<string> { correlationId });
+            request.Headers.Add(xForwardedFor, new List<string> { forwardedFor });
+            request.Headers.Add("Some-Http-Header", new List<string> { "header-value" });
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_CopyMatchingHttpHeaders_UsingSingleExactMatch()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var forwardedFor = "1.1.1.1";
+            var xCorrelationId = "X-Correlation-Id";
+            var xForwardedFor = "X-Forwarded-For";
+
+            var server = CreateResourceServer(options =>
+            {
+                options.SetValuesToMatchFromRequestHttpHeaders(new[] { xCorrelationId }, null);
+                options.Events.OnSendIntrospectionRequest = context =>
+                {
+                    // Assert
+                    var headers = context.Request.Headers;
+                    var keys = headers.Select(x => x.Key).ToArray();
+
+                    Assert.Contains(new[] { xCorrelationId }, (x => keys.Contains(x)));
+                    Assert.Contains(correlationId, headers.Single(x => x.Key.Equals(xCorrelationId, StringComparison.Ordinal)).Value);
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+            request.Headers.Add(xCorrelationId, new List<string> { correlationId });
+            request.Headers.Add(xForwardedFor, new List<string> { forwardedFor });
+            request.Headers.Add("Some-Http-Header", new List<string> { "header-value" });
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_CopyMatchingHttpHeaders_UsingMultipleExactMatches()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var forwardedFor = "1.1.1.1";
+            var xCorrelationId = "X-Correlation-Id";
+            var xForwardedFor = "X-Forwarded-For";
+
+            var server = CreateResourceServer(options =>
+            {
+                options.SetValuesToMatchFromRequestHttpHeaders(new[] { xCorrelationId, xForwardedFor }, null);
+                options.Events.OnSendIntrospectionRequest = context =>
+                {
+                    // Assert
+                    var headers = context.Request.Headers;
+                    var keys = headers.Select(x => x.Key).ToArray();
+
+                    Assert.Contains(new[] { xCorrelationId, xForwardedFor }, (x => keys.Contains(x)));
+                    Assert.Contains(correlationId, headers.Single(x => x.Key.Equals(xCorrelationId, StringComparison.Ordinal)).Value);
+                    Assert.Contains(forwardedFor, headers.Single(x => x.Key.Equals(xForwardedFor, StringComparison.Ordinal)).Value);
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+            request.Headers.Add(xCorrelationId, new List<string> { correlationId });
+            request.Headers.Add(xForwardedFor, new List<string> { forwardedFor });
+            request.Headers.Add("Some-Http-Header", new List<string> { "header-value" });
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        [Fact]
+        public async Task HandleAuthenticateAsync_CopyMatchingHttpHeaders_UsingExactAndPrefixMatches()
+        {
+            // Arrange
+            var correlationId = Guid.NewGuid().ToString();
+            var forwardedFor = "1.1.1.1";
+            var xCorrelationId = "X-Correlation-Id";
+            var xForwardedFor = "X-Forwarded-For";
+            var aHttpHeader = "A-SomeHeader";
+            var aNotherHeader = "A-NotherHeader";
+            var headerPrefixA = "A-";
+            var ahttpHeaderVal = "header-value";
+            var aNotherHeaderVal = "another-header-value";
+
+            var server = CreateResourceServer(options =>
+            {
+                options.SetValuesToMatchFromRequestHttpHeaders(new[] { xCorrelationId, xForwardedFor }, new[] { headerPrefixA });
+                options.Events.OnSendIntrospectionRequest = context =>
+                {
+                    // Assert
+                    var headers = context.Request.Headers;
+                    var keys = headers.Select(x => x.Key).ToArray();
+
+                    Assert.Contains(new[] { xCorrelationId, xForwardedFor, aHttpHeader, aNotherHeader }, (x => keys.Contains(x)));
+                    Assert.Contains(correlationId, headers.Single(x => x.Key.Equals(xCorrelationId, StringComparison.Ordinal)).Value);
+                    Assert.Contains(forwardedFor, headers.Single(x => x.Key.Equals(xForwardedFor, StringComparison.Ordinal)).Value);
+
+                    Assert.Contains(ahttpHeaderVal, headers.Single(x => x.Key.Equals(aHttpHeader, StringComparison.Ordinal)).Value);
+                    Assert.Contains(aNotherHeaderVal, headers.Single(x => x.Key.Equals(aNotherHeader, StringComparison.Ordinal)).Value);
+
+                    return Task.FromResult(0);
+                };
+            });
+
+            var client = server.CreateClient();
+
+            var request = new HttpRequestMessage(HttpMethod.Get, "/");
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", "valid-token");
+            request.Headers.Add(xCorrelationId, new List<string> { correlationId });
+            request.Headers.Add(xForwardedFor, new List<string> { forwardedFor });
+            request.Headers.Add(aHttpHeader, new List<string> { ahttpHeaderVal });
+            request.Headers.Add(aNotherHeader, new List<string> { aNotherHeaderVal });
+            request.Headers.Add("Some-Http-Header", new List<string> { "header-value" });
+
+            // Act
+            var response = await client.SendAsync(request);
+            var content = await response.Content.ReadAsStringAsync();
+
+            // Assert
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
         private static TestServer CreateResourceServer(Action<OAuthIntrospectionOptions> configuration = null)
         {
             var server = CreateAuthorizationServer();


### PR DESCRIPTION
 - add to OAuthIntrospectionOptions ability to set the prefix to use for
 matching HttpHeaders which are to be included in the introspection
 request.

 - include HttpHeaders that match the prefix from the request in the
 introspection request.  Useful when X-Correlation-Id headers, or
 the like, should be included with the introspection request.